### PR TITLE
Minor fixes and minor improvements to TLS parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the "vscode-net-tools" extension will be documented in th
 
 ## 1.x Initial Release
 
+### 1.5.1
+
+* Improved TLS parser slightly
+* Fixed bugs:
+    * Packets with nested protocols failed to highlight or filter correctly when selected
+    * Improved formatting of addresses in interface description block
+    * Inconsistent formatting of ICMPv6 request and reply data
+
 ### 1.5.0
 
 * Added new protocol parsers

--- a/README.md
+++ b/README.md
@@ -56,9 +56,13 @@ Contributions are also welcome!
 
 ## Release Notes
 
-### 1.4.2
+### 1.5.1
 
-* Added .cap to supported file extensions
+* Improved TLS parser slightly
+* Fixed bugs:
+    * Packets with nested protocols failed to highlight or filter correctly when selected
+    * Improved formatting of addresses in interface description block
+    * Inconsistent formatting of ICMPv6 request and reply data
 
 ### 1.5.0
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vscode-net-tools",
   "displayName": "Network Tools",
   "description": "Network tools, including pcap and pcapng file parser and viewer",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "publisher": "CusanzaBros",
   "repository": "https://github.com/CusanzaBros/vscode-net-tools",
   "license": "MIT",

--- a/src/parsers/file/section.ts
+++ b/src/parsers/file/section.ts
@@ -6,6 +6,7 @@ import { IPv6Packet } from "../packet/ipv6Packet";
 import { Node } from "../../packetdetailstree";
 import * as vscode from 'vscode';
 import { FileType, FileContext } from "./FileContext";
+import { Address6 } from "ip-address";
 
 function getLinkName(id:number):string {
 	switch (id) {
@@ -683,6 +684,49 @@ export class PCAPNGInterfaceDescriptionBlock extends PCAPNGSection {
 		return arr;
 	}
 	
+	private IPv4AddressToString(value:DataView):string {
+		let ret = "";
+		ret += value.getUint8(0) + ".";
+		ret += value.getUint8(1) + ".";
+		ret += value.getUint8(2) + ".";
+		ret += value.getUint8(3);
+		return ret;
+	}
+
+	private IPv6AddressToString(value:DataView):string {
+		const v6: number[] = [
+			value.getUint8(0),
+			value.getUint8(1),
+			value.getUint8(2),
+			value.getUint8(3),
+			value.getUint8(4),
+			value.getUint8(5),
+			value.getUint8(6),
+			value.getUint8(7),
+			value.getUint8(8),
+			value.getUint8(9),
+			value.getUint8(10),
+			value.getUint8(11),
+			value.getUint8(12),
+			value.getUint8(13),
+			value.getUint8(14),
+			value.getUint8(15)
+		];
+		return Address6.fromByteArray(v6).correctForm();
+	}
+
+	private MacAddressToString(value:DataView):string {
+		let ret = "";
+		ret += value.getUint8(0).toString(16).padStart(2, "0") + ":";
+		ret += value.getUint8(1).toString(16).padStart(2, "0") + ":";
+		ret += value.getUint8(2).toString(16).padStart(2, "0") + ":";
+		ret += value.getUint8(3).toString(16).padStart(2, "0") + ":";
+		ret += value.getUint8(4).toString(16).padStart(2, "0") + ":";
+		ret += value.getUint8(5).toString(16).padStart(2, "0");
+		return ret.toUpperCase();
+	}
+
+
 	get getProperties(): Node[] {
 		const decoder = new TextDecoder('utf-8');
 
@@ -703,13 +747,13 @@ export class PCAPNGInterfaceDescriptionBlock extends PCAPNGSection {
 						e.children.push(new Node(`Description`, `${decoder.decode(o.value)}`));
 						break;
 					case 4:
-						e.children.push(new Node(`IPv4 Address`, `${decoder.decode(o.value)}`));
+						e.children.push(new Node(`IPv4 Address`, `${this.IPv4AddressToString(o.value)}`));
 						break;
 					case 5:
-						e.children.push(new Node(`IPv6 Address`, `${decoder.decode(o.value)}`));
+						e.children.push(new Node(`IPv6 Address`, `${this.IPv6AddressToString(o.value)}`));
 						break;
 					case 6:
-						e.children.push(new Node(`MAC Address`, `${decoder.decode(o.value)}`));
+						e.children.push(new Node(`MAC Address`, `${this.MacAddressToString(o.value)}`));
 						break;
 					case 7:
 						e.children.push(new Node(`EUI Address`, `${decoder.decode(o.value)}`));

--- a/src/parsers/packet/icmpv6Packet.ts
+++ b/src/parsers/packet/icmpv6Packet.ts
@@ -168,7 +168,7 @@ class ICMPv6EchoRequest extends ICMPv6Info {
     get data() {
         let ret = "";
 		for (let i = ICMPv6EchoRequest._DataOffset; i < this.packet.byteLength; i++) {
-			ret += this.packet.getUint8(i).toString(16).padStart(2, "0");
+			ret += this.packet.getUint8(i).toString(16).padStart(2, "0") + " ";
 		}
 		return ret;
     }

--- a/src/pcapviewer.ts
+++ b/src/pcapviewer.ts
@@ -259,7 +259,7 @@ export class pcapViewerProvider implements vscode.CustomReadonlyEditorProvider<p
 		this.lastNode = node;
 
 		for (let w of this.webviews.get(uri)) {
-			let r = w.webview.postMessage({ command: 'customevent', filterMode: this.isFilter, data: node.items });
+			let r = w.webview.postMessage({ command: 'customevent', filterMode: this.isFilter, data: [...node.items] });
 		}
 	}
 
@@ -312,18 +312,18 @@ export class pcapViewerProvider implements vscode.CustomReadonlyEditorProvider<p
 
 		const ie = elements[1].children;
 		for (let entry of document.fc.interfaces) {
-			const arr: number[] = []; 
+			const arr = new Set<number>(); 
 			for (let s of entry[1]) {
-				arr.push(s.lineNumber);
+				arr.add(s.lineNumber);
 			}
 			ie.push(new ProtocolNode(entry[0], `${entry[1].length} ${entry[1].length > 1 ? "packets" : "packet"}`,vscode.TreeItemCollapsibleState.None, arr));
 		}
 
 		const pe = elements[2].children;
 		for (let entry of [...document.fc.protocols].sort((a, b) => a[0].localeCompare(b[0]))) {
-			const arr: number[] = []; 
+			const arr = new Set<number>(); 
 			for (let s of entry[1]) {
-				arr.push(s.lineNumber);
+				arr.add(s.lineNumber);	
 			}
 			pe.push(new ProtocolNode(entry[0], `${entry[1].length} ${entry[1].length > 1 ? "packets" : "packet"}`,vscode.TreeItemCollapsibleState.None, arr));
 		}
@@ -344,9 +344,9 @@ export class pcapViewerProvider implements vscode.CustomReadonlyEditorProvider<p
 		ae.push(ipv6);
 
 		for (let entry of [...document.fc.addresses].sort((a, b) => a[0].localeCompare(b[0]))) {
-			const arr: number[] = []; 
+			const arr = new Set<number>(); 
 			for (let s of entry[1]) {
-				arr.push(s.lineNumber);
+				arr.add(s.lineNumber);
 			}
 			let push = ae;
 			switch (this.getAddressType(entry[0])) {

--- a/src/protocolanalysis.ts
+++ b/src/protocolanalysis.ts
@@ -26,7 +26,7 @@ export class ProtocolNode extends vscode.TreeItem {
     public readonly label: string,
     private version?: string,
     public readonly collapsibleState?: vscode.TreeItemCollapsibleState,
-    public items: number[] = []
+    public items:Set<number> = new Set<number>()
   ) {
     super(label, collapsibleState);
     this.description = this.version;


### PR DESCRIPTION
### 1.5.1

* Improved TLS parser slightly
* Fixed bugs:
    * Packets with nested protocols failed to highlight or filter correctly when selected
    * Improved formatting of addresses in interface description block
    * Inconsistent formatting of ICMPv6 request and reply data